### PR TITLE
Access props directly

### DIFF
--- a/dist/src/HighchartsReactNative.js
+++ b/dist/src/HighchartsReactNative.js
@@ -16,12 +16,12 @@ export default class HighchartsReactNative extends React.PureComponent {
         super(props);
 
         // extract width and height from user styles
-        const userStyles = StyleSheet.flatten(this.props.styles);
+        const userStyles = StyleSheet.flatten(props.styles);
 
         this.state = {
             width: userStyles.width || win.width,
             height: userStyles.height || win.height,
-            chartOptions: this.props.options
+            chartOptions: props.options
         };
 
         // create script tag and apply all references


### PR DESCRIPTION
So, the idea is to access directly because props are at the same scope.