### PR TITLE
Feature: support setOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ Official minimal [Highcharts](https://www.highcharts.com/) wrapper for React Nat
     4. [How to run](#how-to-run)
 2. [Options details](#options-details)
     1. [options](#options)
-    2. [styles](#styles)
-    3. [modules](#modules)
-    4. [callback](#callback)
-    5. [useSSL](#useSSL)
-    6. [useCDN](#useCDN)
-    7. [data](#data)
-    8. [onMessage](#onMessage)
+    2. [setOptions](#setOptions)
+    3. [styles](#styles)
+    4. [modules](#modules)
+    5. [callback](#callback)
+    6. [useSSL](#useSSL)
+    7. [useCDN](#useCDN)
+    8. [data](#data)
+    9. [onMessage](#onMessage)
 3. [Get repository](#get-repository)
 4. [FAQ](#faq)
     1. [Where to look for help?](#where-to-look-for-help)
@@ -319,6 +320,27 @@ You can style your container using JavaScript like in the regular react and reac
 ### options
 
 Highcharts chart configuration object. Please refer to the Highcharts [API documentation](https://api.highcharts.com/highcharts/). This option is required.
+
+### setOptions
+
+Highcharts chart configuration object. Please refer to the Highcharts [API documentation](https://api.highcharts.com/highcharts/). This option is optional.
+
+```js
+const setOptions={
+    // Language object. The language object is global and it can't be set on each chart initialization. Instead, use Highcharts.setOptions to set it before any chart is initialized.
+    lang: {
+        months: [
+            'Janvier', 'Février', 'Mars', 'Avril',
+            'Mai', 'Juin', 'Juillet', 'Août',
+            'Septembre', 'Octobre', 'Novembre', 'Décembre'
+        ],
+        weekdays: [
+            'Dimanche', 'Lundi', 'Mardi', 'Mercredi',
+            'Jeudi', 'Vendredi', 'Samedi'
+        ]
+    }
+}
+```
 
 ### modules
 List of modules which should be added to Highcharts. I.e when you would like to setup `solidgauge` series which requires `highcharts-more` and `solid-gauge` files, you should declare array:

--- a/dist/src/HighchartsReactNative.js
+++ b/dist/src/HighchartsReactNative.js
@@ -30,7 +30,8 @@ export default class HighchartsReactNative extends React.PureComponent {
             height: userStyles.height || win.height,
             chartOptions: props.options,
             useCDN: props.useCDN || false,
-            modules: props.modules && props.modules.toString() || []
+            modules: props.modules && props.modules.toString() || [],
+            setOptions: props.setOptions || {}
         };
 
         // catch rotation event
@@ -97,6 +98,8 @@ export default class HighchartsReactNative extends React.PureComponent {
     }
     render() {
         const scriptsPath = this.state.useCDN ? httpProto.concat(cdnPath) : path;
+        const setOptions = this.state.setOptions;
+
         const runFirst = `
            window.data = \"${this.props.data ? this.props.data : null}\";
            var modulesList = ${JSON.stringify(this.state.modules)};
@@ -120,6 +123,7 @@ export default class HighchartsReactNative extends React.PureComponent {
                     }
 
                     if (redraw) {
+                        Highcharts.setOptions('${setOptions}');
                         Highcharts.chart("container", ${this.serialize(this.props.options)});
                     }
                 }


### PR DESCRIPTION
## Feature: support setOptions

```js
Highcharts.setOptions({
    lang: {
        months: [
            'Janvier', 'Février', 'Mars', 'Avril',
            'Mai', 'Juin', 'Juillet', 'Août',
            'Septembre', 'Octobre', 'Novembre', 'Décembre'
        ],
        weekdays: [
            'Dimanche', 'Lundi', 'Mardi', 'Mercredi',
            'Jeudi', 'Vendredi', 'Samedi'
        ]
    }
});
```

It seems very easy to get confused about [options](https://github.com/highcharts/highcharts-react-native#options)  and [setOptions](https://github.com/highcharts/highcharts-react-native#setOptions)  variable name