### PR TITLE
update dimensions state on new styles prop

### DIFF
--- a/dist/src/HighchartsReactNative.js
+++ b/dist/src/HighchartsReactNative.js
@@ -16,6 +16,20 @@ let highchartsLayout;
 let httpProto = 'http://';
 
 export default class HighchartsReactNative extends React.PureComponent {
+    static getDerivedStateFromProps(props, state) {
+        let width = Dimensions.get('window').width;
+        let height =  Dimensions.get('window').height;
+        if(!!props.styles) {
+            const userStyles = StyleSheet.flatten(props.styles);
+            const {width: w, height: h} = userStyles;
+            width = w;
+            height = h;
+        }
+        return {
+            width: width,
+            height: height,
+        };
+    }
     constructor(props) {
         super(props);
 

--- a/dist/src/HighchartsReactNative.js
+++ b/dist/src/HighchartsReactNative.js
@@ -53,33 +53,9 @@ export default class HighchartsReactNative extends React.PureComponent {
         };
 
         this.webviewRef = null
-
-        // catch rotation event
-        this.onRotate = this.onRotate.bind(this);
     }
     componentDidUpdate() {
         this.webviewRef && this.webviewRef.postMessage(this.serialize(this.props.options, true));
-    }
-    componentDidMount() {
-        // catch rotation event
-        Dimensions.addEventListener('change', this.onRotate);
-    }
-    componentWillUnmount() {
-        Dimensions.removeEventListener('change', this.onRotate);
-    }
-    onRotate() {
-        let width = Dimensions.get('window').width;
-        let height =  Dimensions.get('window').height;
-        if(!!this.props.styles) {
-            const userStyles = StyleSheet.flatten(this.props.styles);
-            const {width: w, height: h} = userStyles;
-            width = w;
-            height = h;
-        }
-        this.setState({
-            width: width,
-            height: height,
-        });
     }
     /**
      * Convert JSON to string. When is updated, functions (like events.load) 


### PR DESCRIPTION
# What is it for
In current implementation `width` and `height` can only be updated on device rotation, if parent component passes new `styles` prop it does not trigger component to update internal `width` and `height` state. This pull request adds ability to update `width` and `height` of component after initial values were set, without the need for devise rotation