### PR TITLE
correctly pass setOptions parameters

### DIFF
--- a/dist/src/HighchartsReactNative.js
+++ b/dist/src/HighchartsReactNative.js
@@ -173,7 +173,7 @@ export default class HighchartsReactNative extends React.PureComponent {
                     }
 
                     if (redraw) {
-                        Highcharts.setOptions('${this.serialize(setOptions)}');
+                        Highcharts.setOptions(${this.serialize(setOptions)});
                         Highcharts.chart("container", ${this.serialize(this.props.options)});
                     }
                 }


### PR DESCRIPTION
setOptions parameters are not passed to the highcharts instance in the web view.
replace
`Highcharts.setOptions('${this.serialize(setOptions)'}); // remove quote`
by
`Highcharts.setOptions(${this.serialize(setOptions)});`