### PR TITLE
Allow use with RN Uni-modules 0.14+

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@highcharts/highcharts-react-native",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "license": "SEE LICENSE IN <LICENSE>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/highcharts/highcharts-react-native-official.git"
   },
   "dependencies": {
-    "metro-config": "^0.60.0",
-    "react-native-unimodules": "^0.10.1"
+    "metro-config": "^0.66.2",
+    "react-native-unimodules": "^0.14.5"
   },
   "keywords": [
     "highcharts",
@@ -32,12 +32,12 @@
     "react-native-webview": "^10.6.0"
   },
   "devDependencies": {
-    "eslint": "^5.16.0",
+    "eslint": "^7.31.0",
     "eslint-plugin-react": "^7.12.4",
-    "react": "^16.4.0",
+    "react": "^17.0.2",
     "react-addons-test-utils": "^15.6.2",
-    "react-dom": "^16.4.0",
-    "react-test-renderer": "^16.4.0",
-    "react-unit": "^3.0.0"
+    "react-dom": "^17.0.2",
+    "react-test-renderer": "^17.0.2",
+    "react-unit": "^3.0.3"
   }
 }


### PR DESCRIPTION
Update dependecies in package.json. Old dependencies prevented builds of projects using the latest RN Unimodules due to a conflict on the expo-permissions node-module causing duplicate symbols on iOS.

This fixes that error.